### PR TITLE
Импорт модулей Threejs

### DIFF
--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -1,4 +1,5 @@
 import * as THREE from 'three';
+import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls';
 
 const scene = new THREE.Scene();
 
@@ -14,6 +15,8 @@ camera.position.z = 2;
 const renderer = new THREE.WebGLRenderer();
 renderer.setSize(window.innerWidth, window.innerHeight);
 document.body.appendChild(renderer.domElement);
+
+new OrbitControls(camera, renderer.domElement);
 
 const geometry = new THREE.BoxGeometry();
 const material = new THREE.MeshBasicMaterial({


### PR DESCRIPTION
Ядро Three.js сосредоточено на наиболее важных компонентах 3D-движка.

Многие дополнительные модули, такие как загрузчик 3D-моделей и элементы управления являются частью директории examples.

Если мы хотим использовать эти модули в своем проекте, нам надо импортировать их отдельно.

Каталог `./node_modules/three/examples/jsm/`, который был установлен как часть Threejs, содержит множество полезных дополнительных модулей.
 
