### PR TITLE
Цикл анимации

### DIFF
--- a/dist/client/index.html
+++ b/dist/client/index.html
@@ -9,34 +9,10 @@
             overflow: hidden;
             margin: 0px;
         }
-
-        #c1 {
-          width: 200;
-          height: 200;
-        }
-
-        #c2 {
-          width: 200;
-          height: 200;
-        }
-
-        #c3 {
-          width: 200;
-          height: 200;
-        }
-
-        #c4 {
-          width: 200;
-          height: 200;
-        }
     </style>
   </head>
 
   <body>
-    <canvas id="c1"></canvas>
-    <canvas id="c2"></canvas>
-    <canvas id="c3"></canvas>
-    <canvas id="c4"></canvas>
     <script type="module" src="bundle.js"></script>
   </body>
 </html>

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -38,14 +38,15 @@ function onWindowResize() {
 function animate() {
   requestAnimationFrame(animate);
 
-  cube.rotation.x += 0.01;
-  cube.rotation.y += 0.01;
+  // cube.rotation.x += 0.01;
+  // cube.rotation.y += 0.01;
 
-  render();
+  // render();
 }
 
 function render() {
   renderer.render(scene, camera);
 }
 
-animate();
+// animate();
+render();

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -16,7 +16,8 @@ const renderer = new THREE.WebGLRenderer();
 renderer.setSize(window.innerWidth, window.innerHeight);
 document.body.appendChild(renderer.domElement);
 
-new OrbitControls(camera, renderer.domElement);
+const controls = new OrbitControls(camera, renderer.domElement);
+controls.addEventListener('change', render);
 
 const geometry = new THREE.BoxGeometry();
 const material = new THREE.MeshBasicMaterial({

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -3,51 +3,20 @@ import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls';
 
 const scene = new THREE.Scene();
 
-const camera1 = new THREE.PerspectiveCamera(
+const camera = new THREE.PerspectiveCamera(
   75,
-  1,
+  window.innerWidth / window.innerHeight,
   0.1,
   1000
 );
 
-const camera2 = new THREE.OrthographicCamera(
-  -1,   // left
-  1,    // right
-  1,    // top
-  -1    // bottom
-);
+camera.position.z = 2;
 
-const camera3 = new THREE.OrthographicCamera(-1, 1, 1, -1, 0.1, 10);
-const camera4 = new THREE.OrthographicCamera(-1, 1, 1, -1, 0.1, 10);
+const renderer = new THREE.WebGLRenderer();
+renderer.setSize(window.innerWidth, window.innerHeight);
+document.body.appendChild(renderer.domElement);
 
-camera1.position.z = 2;
-camera2.position.y = 2;
-camera2.lookAt(new THREE.Vector3()); // look top down to the cube
-
-camera3.position.x = -2;
-camera3.lookAt(new THREE.Vector3()); // look right to the cube
-
-camera4.position.z = 2;              // look front to the cube
-
-const canvas1 = <HTMLCanvasElement>document.querySelector('#c1');
-const canvas2 = <HTMLCanvasElement>document.querySelector('#c2');
-const canvas3 = <HTMLCanvasElement>document.querySelector('#c3');
-const canvas4 = <HTMLCanvasElement>document.querySelector('#c4');
-
-const renderer1 = new THREE.WebGLRenderer({ canvas: canvas1 });
-renderer1.setSize(200, 200);
-// document.body.appendChild(renderer.domElement);
-
-const renderer2 = new THREE.WebGLRenderer({ canvas: canvas2 });
-renderer2.setSize(200, 200);
-
-const renderer3 = new THREE.WebGLRenderer({ canvas: canvas3 });
-renderer3.setSize(200, 200);
-
-const renderer4 = new THREE.WebGLRenderer({ canvas: canvas4 });
-renderer4.setSize(200, 200);
-
-new OrbitControls(camera1, renderer1.domElement);
+new OrbitControls(camera, renderer.domElement);
 
 const geometry = new THREE.BoxGeometry();
 const material = new THREE.MeshBasicMaterial({
@@ -58,13 +27,13 @@ const material = new THREE.MeshBasicMaterial({
 const cube = new THREE.Mesh(geometry, material);
 scene.add(cube);
 
-// window.addEventListener('resize', onWindowResize, false);
-// function onWindowResize() {
-//   camera.aspect = window.innerWidth / window.innerHeight;
-//   camera.updateProjectionMatrix();
-//   renderer.setSize(window.innerWidth, window.innerHeight);
-//   render();
-// }
+window.addEventListener('resize', onWindowResize, false);
+function onWindowResize() {
+  camera.aspect = window.innerWidth / window.innerHeight;
+  camera.updateProjectionMatrix();
+  renderer.setSize(window.innerWidth, window.innerHeight);
+  render();
+}
 
 function animate() {
   requestAnimationFrame(animate);
@@ -76,10 +45,7 @@ function animate() {
 }
 
 function render() {
-  renderer1.render(scene, camera1);
-  renderer2.render(scene, camera2);
-  renderer3.render(scene, camera3);
-  renderer4.render(scene, camera4);
+  renderer.render(scene, camera);
 }
 
 animate();

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -36,14 +36,14 @@ function onWindowResize() {
   render();
 }
 
-function animate() {
-  requestAnimationFrame(animate);
+// function animate() {
+//   requestAnimationFrame(animate);
 
-  // cube.rotation.x += 0.01;
-  // cube.rotation.y += 0.01;
+//   cube.rotation.x += 0.01;
+//   cube.rotation.y += 0.01;
 
-  // render();
-}
+//   render();
+// }
 
 function render() {
   renderer.render(scene, camera);


### PR DESCRIPTION
Метод `window.requestAnimationFrame(() => {})` сообщает браузеру, что мы хотим выполнить анимацию, и запрашивает, чтобы браузер вызвал указанную функцию для обновления анимации перед следующей перерисовкой. Метод принимает обратный вызов в качестве аргумента, который должен быть вызван перед перерисовкой.

> Процедура обратного вызова должна вызывать `requestAnimationFrame()` если мы хотим анимировать другой кадр при  при следующем пере рисовании.

Количество обратных вызовов обычно составляет 60 раз в секунду, что обычно соответствует частоте обновления экрана в большинстве веб-браузеров в соответствии с W3C.
`requestAnimationFrame()` вызов обычно приостанавливается в большинстве браузеров при работе в фоновых вкладках или скрытых <iframe> с целью повышения производительности и времени автономной работы.
 

