### PR TITLE
Dat.GUI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,9 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
+        "@types/dat.gui": "^0.7.7",
         "@types/three": "^0.144.0",
+        "dat.gui": "^0.7.9",
         "three": "^0.144.0",
         "ts-loader": "^9.3.1",
         "typescript": "^4.8.3",
@@ -129,6 +131,12 @@
         "@types/express-serve-static-core": "*",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/dat.gui": {
+      "version": "0.7.7",
+      "resolved": "https://registry.npmjs.org/@types/dat.gui/-/dat.gui-0.7.7.tgz",
+      "integrity": "sha512-CxLCme0He5Jk3uQwfO/fGZMyNhb/ypANzqX0yU9lviBQMlen5SOvQTBQ/Cd9x5mFlUAK5Tk8RgvTyLj1nYkz+w==",
+      "dev": true
     },
     "node_modules/@types/eslint": {
       "version": "8.4.6",
@@ -976,6 +984,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/dat.gui": {
+      "version": "0.7.9",
+      "resolved": "https://registry.npmjs.org/dat.gui/-/dat.gui-0.7.9.tgz",
+      "integrity": "sha512-sCNc1OHobc+Erc1HqiswYgHdVNpSJUlk/Hz8vzOCsER7rl+oF/4+v8GXFUyCgtXpoCX6+bnmg07DedLvBLwYKQ==",
+      "dev": true
     },
     "node_modules/debug": {
       "version": "2.6.9",
@@ -3652,6 +3666,12 @@
         "@types/node": "*"
       }
     },
+    "@types/dat.gui": {
+      "version": "0.7.7",
+      "resolved": "https://registry.npmjs.org/@types/dat.gui/-/dat.gui-0.7.7.tgz",
+      "integrity": "sha512-CxLCme0He5Jk3uQwfO/fGZMyNhb/ypANzqX0yU9lviBQMlen5SOvQTBQ/Cd9x5mFlUAK5Tk8RgvTyLj1nYkz+w==",
+      "dev": true
+    },
     "@types/eslint": {
       "version": "8.4.6",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.6.tgz",
@@ -4355,6 +4375,12 @@
         "shebang-command": "^2.0.0",
         "which": "^2.0.1"
       }
+    },
+    "dat.gui": {
+      "version": "0.7.9",
+      "resolved": "https://registry.npmjs.org/dat.gui/-/dat.gui-0.7.9.tgz",
+      "integrity": "sha512-sCNc1OHobc+Erc1HqiswYgHdVNpSJUlk/Hz8vzOCsER7rl+oF/4+v8GXFUyCgtXpoCX6+bnmg07DedLvBLwYKQ==",
+      "dev": true
     },
     "debug": {
       "version": "2.6.9",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
+    "@types/dat.gui": "^0.7.7",
     "@types/three": "^0.144.0",
+    "dat.gui": "^0.7.9",
     "three": "^0.144.0",
     "ts-loader": "^9.3.1",
     "typescript": "^4.8.3",

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -46,6 +46,7 @@ const cubeFolder = gui.addFolder("Cube");
 cubeFolder.add(cube.rotation, "x", 0, Math.PI * 2);
 cubeFolder.add(cube.rotation, "y", 0, Math.PI * 2);
 cubeFolder.add(cube.rotation, "z", 0, Math.PI * 2);
+cubeFolder.open();
 
 function animate() {
   requestAnimationFrame(animate);

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -42,9 +42,10 @@ const stats = Stats();
 document.body.appendChild(stats.dom);
 
 const gui = new GUI();
-gui.add(cube.rotation, "x", 0, Math.PI * 2);
-gui.add(cube.rotation, "y", 0, Math.PI * 2);
-gui.add(cube.rotation, "z", 0, Math.PI * 2);
+const cubeFolder = gui.addFolder("Cube");
+cubeFolder.add(cube.rotation, "x", 0, Math.PI * 2);
+cubeFolder.add(cube.rotation, "y", 0, Math.PI * 2);
+cubeFolder.add(cube.rotation, "z", 0, Math.PI * 2);
 
 function animate() {
   requestAnimationFrame(animate);

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -42,6 +42,7 @@ const stats = Stats();
 document.body.appendChild(stats.dom);
 
 const gui = new GUI();
+gui.add(cube.rotation, "x", 0, Math.PI * 2);
 
 function animate() {
   requestAnimationFrame(animate);

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -48,6 +48,10 @@ cubeFolder.add(cube.rotation, "y", 0, Math.PI * 2);
 cubeFolder.add(cube.rotation, "z", 0, Math.PI * 2);
 cubeFolder.open();
 
+const cameraFolder = gui.addFolder("Camera");
+cameraFolder.add(camera.position, "z", 0, 20);
+cameraFolder.open();
+
 function animate() {
   requestAnimationFrame(animate);
 

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -1,6 +1,7 @@
 import * as THREE from 'three';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls';
 import Stats from 'three/examples/jsm/libs/stats.module';
+import { GUI } from 'dat.gui';
 
 const scene = new THREE.Scene();
 
@@ -39,6 +40,9 @@ function onWindowResize() {
 
 const stats = Stats();
 document.body.appendChild(stats.dom);
+
+const gui = new GUI();
+
 function animate() {
   requestAnimationFrame(animate);
 

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -43,12 +43,14 @@ document.body.appendChild(stats.dom);
 
 const gui = new GUI();
 gui.add(cube.rotation, "x", 0, Math.PI * 2);
+gui.add(cube.rotation, "y", 0, Math.PI * 2);
+gui.add(cube.rotation, "z", 0, Math.PI * 2);
 
 function animate() {
   requestAnimationFrame(animate);
 
-  cube.rotation.x += 0.01;
-  cube.rotation.y += 0.01;
+  // cube.rotation.x += 0.01;
+  // cube.rotation.y += 0.01;
   
   render();
   stats.update();

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -42,10 +42,8 @@ document.body.appendChild(stats.dom);
 function animate() {
   requestAnimationFrame(animate);
 
-  // stats.begin();
   cube.rotation.x += 0.01;
   cube.rotation.y += 0.01;
-  // stats.end();
   
   render();
   stats.update();


### PR DESCRIPTION
**Dat.GUI** - еще один очень полезный инструмент, который мы можем использовать для изучения Three.js, поскольку он позволяет нам быстро добавить очень простой пользовательский интерфейс, который позволяет нам взаимодействовать с нашей 3D-сценой и объектами внутри.

Dat.GUI устанавливается отдельно:
`npm install --save-dev dat.gui @types/dat.gui`

 