### PR TITLE
MeshPhongMaterial

### DIFF
--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -10,7 +10,7 @@ scene.add(new THREE.AxesHelper(5));
 const windowCenter = window.innerWidth / window.innerHeight;
 
 const light = new THREE.PointLight(0xffffff, 2);
-light.position.set(2, 2, 2);
+light.position.set(10, 10, 10);
 scene.add(light);
 
 const camera = new THREE.PerspectiveCamera(75, windowCenter, 0.1, 1000);
@@ -28,10 +28,10 @@ const icosahedronGeometry = new THREE.IcosahedronGeometry(1, 0);
 const planeGeometry = new THREE.PlaneGeometry();
 const torusKnotGeometry = new THREE.TorusKnotGeometry();
 
-const material = new THREE.MeshLambertMaterial();
+const material = new THREE.MeshPhongMaterial();
 
-const texture = new THREE.TextureLoader().load("img/grid.png")
-material.map = texture
+// const texture = new THREE.TextureLoader().load("img/grid.png")
+// material.map = texture
 // const envTexture = new THREE.CubeTextureLoader().load(["img/px_50.png", "img/nx_50.png", "img/py_50.png", "img/ny_50.png", "img/pz_50.png", "img/nz_50.png"])
 // envTexture.mapping = THREE.CubeReflectionMapping
 // envTexture.mapping = THREE.CubeRefractionMapping
@@ -67,6 +67,7 @@ function onWindowResize() {
 
 const stats = Stats();
 document.body.appendChild(stats.dom);
+
 const options = {
   side: {
       FrontSide: THREE.FrontSide,
@@ -80,41 +81,49 @@ const options = {
   },
 };
 
-const gui = new GUI()
+const gui = new GUI();
 const materialFolder = gui.addFolder('THREE.Material');
 materialFolder.add(material, 'transparent').onChange(() => material.needsUpdate = true);
 materialFolder.add(material, 'opacity', 0, 1, 0.01);
 materialFolder.add(material, 'depthTest');
 materialFolder.add(material, 'depthWrite');
 materialFolder
-  .add(material, 'alphaTest', 0, 1, 0.01)
-  .onChange(() => updateMaterial());
+    .add(material, 'alphaTest', 0, 1, 0.01)
+    .onChange(() => updateMaterial());
 materialFolder.add(material, 'visible');
 materialFolder
-  .add(material, 'side', options.side)
-  .onChange(() => updateMaterial());
+    .add(material, 'side', options.side)
+    .onChange(() => updateMaterial());
 materialFolder.open();
 
 const data = {
-  color: material.color.getHex(),
-  emissive: material.emissive.getHex(),
+    color: material.color.getHex(),
+    emissive: material.emissive.getHex(),
+    //specular: material.specular.getHex()
 };
 
-const meshLambertMaterialFolder = gui.addFolder('THREE.MeshLambertMaterial');
-
-meshLambertMaterialFolder.addColor(data, 'color').onChange(() => {
-  material.color.setHex(Number(data.color.toString().replace('#', '0x')));
+const meshPhongMaterialFolder = gui.addFolder('THREE.MeshPhongMaterial')
+meshPhongMaterialFolder.addColor(data, 'color').onChange(() => {
+    material.color.setHex(Number(data.color.toString().replace('#', '0x')));
 });
-meshLambertMaterialFolder.addColor(data, 'emissive').onChange(() => { material.emissive.setHex(Number(data.emissive.toString().replace('#', '0x'))) });
-meshLambertMaterialFolder.add(material, 'wireframe');
-meshLambertMaterialFolder.add(material, 'wireframeLinewidth', 0, 10);
-//meshLambertMaterialFolder.add(material, 'flatShading').onChange(() => updateMaterial());
-meshLambertMaterialFolder
-  .add(material, 'combine', options.combine)
-  .onChange(() => updateMaterial());
-meshLambertMaterialFolder.add(material, 'reflectivity', 0, 1);
-meshLambertMaterialFolder.add(material, 'refractionRatio', 0, 1);
-meshLambertMaterialFolder.open();
+meshPhongMaterialFolder.addColor(data, 'emissive').onChange(() => {
+    material.emissive.setHex(
+        Number(data.emissive.toString().replace('#', '0x'))
+    );
+});
+//meshPhongMaterialFolder.addColor(data, 'specular').onChange(() => { material.specular.setHex(Number(data.specular.toString().replace('#', '0x'))) });
+//meshPhongMaterialFolder.add(material, 'shininess', 0, 1024);
+meshPhongMaterialFolder.add(material, 'wireframe');
+meshPhongMaterialFolder.add(material, 'wireframeLinewidth', 0, 10);
+meshPhongMaterialFolder
+    .add(material, 'flatShading')
+    .onChange(() => updateMaterial());
+meshPhongMaterialFolder
+    .add(material, 'combine', options.combine)
+    .onChange(() => updateMaterial());
+meshPhongMaterialFolder.add(material, 'reflectivity', 0, 1);
+meshPhongMaterialFolder.add(material, 'refractionRatio', 0, 1);
+meshPhongMaterialFolder.open();
 
 function updateMaterial() {
   material.side = Number(material.side)

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -13,6 +13,10 @@ const light = new THREE.PointLight(0xffffff, 2);
 light.position.set(10, 10, 10);
 scene.add(light);
 
+const light2 = new THREE.PointLight(0xffffff, 2);
+light2.position.set(-10, -10, -10);
+scene.add(light2);
+
 const camera = new THREE.PerspectiveCamera(75, windowCenter, 0.1, 1000);
 camera.position.z = 3;
 
@@ -99,7 +103,7 @@ materialFolder.open();
 const data = {
     color: material.color.getHex(),
     emissive: material.emissive.getHex(),
-    //specular: material.specular.getHex()
+    specular: material.specular.getHex()
 };
 
 const meshPhongMaterialFolder = gui.addFolder('THREE.MeshPhongMaterial')
@@ -111,8 +115,8 @@ meshPhongMaterialFolder.addColor(data, 'emissive').onChange(() => {
         Number(data.emissive.toString().replace('#', '0x'))
     );
 });
-//meshPhongMaterialFolder.addColor(data, 'specular').onChange(() => { material.specular.setHex(Number(data.specular.toString().replace('#', '0x'))) });
-//meshPhongMaterialFolder.add(material, 'shininess', 0, 1024);
+meshPhongMaterialFolder.addColor(data, 'specular').onChange(() => { material.specular.setHex(Number(data.specular.toString().replace('#', '0x'))) });
+meshPhongMaterialFolder.add(material, 'shininess', 0, 1024);
 meshPhongMaterialFolder.add(material, 'wireframe');
 meshPhongMaterialFolder.add(material, 'wireframeLinewidth', 0, 10);
 meshPhongMaterialFolder


### PR DESCRIPTION
Использует модель отражения Блинна-Фонга.
Это полезно для имитации блестящих объектов, таких как полированное дерево.
Его использование требует больше вычислительных ресурсов, чем MeshLambertMaterial, MeshNormalMaterial и MeshBasicMaterial.
