### PR TITLE
NormalMap

### DIFF
--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -7,7 +7,7 @@ const scene = new THREE.Scene()
 scene.add(new THREE.AxesHelper(5))
 
 const light = new THREE.PointLight(0xffffff, 2)
-light.position.set(0, 5, 10)
+light.position.set(0, 2, 5)
 scene.add(light)
 
 const camera = new THREE.PerspectiveCamera(
@@ -32,9 +32,11 @@ const material = new THREE.MeshPhongMaterial()
 const texture = new THREE.TextureLoader().load('img/worldColour.5400x2700.jpg')
 material.map = texture
 
-const bumpTexture = new THREE.TextureLoader().load('img/earth_bumpmap.jpg')
-material.bumpMap = bumpTexture
-material.bumpScale = 0.015
+const normalTexture = new THREE.TextureLoader().load(
+    'img/earth_normalmap_8192x4096.jpg'
+)
+material.normalMap = normalTexture
+material.normalScale.set(2, 2)
 
 const plane = new THREE.Mesh(planeGeometry, material)
 scene.add(plane)
@@ -51,7 +53,9 @@ const stats = Stats()
 document.body.appendChild(stats.dom)
 
 const gui = new GUI()
-gui.add(material, 'bumpScale', 0, 1, 0.01)
+gui.add(material.normalScale, 'x', 0, 10, 0.01)
+gui.add(material.normalScale, 'y', 0, 10, 0.01)
+gui.add(light.position, 'x', -20, 20).name('Light Pos X')
 
 function animate() {
     requestAnimationFrame(animate)


### PR DESCRIPTION
NormalMap использует значение rgb, чтобы повлиять на освещение.

Он также имитирует воспринимаемую глубину по отношению к источникам света. 
`normalScale` получает `THREE.Vector2`. Обычно `x, y` значение `normalScale` между `0` и `1.0`. 