### PR TITLE
Custom Mipmap

### DIFF
--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -28,14 +28,45 @@ new OrbitControls(camera, renderer.domElement)
 const planeGeometry1 = new THREE.PlaneGeometry()
 const planeGeometry2 = new THREE.PlaneGeometry()
 
-const texture1 = new THREE.TextureLoader().load('img/grid.png')
+// const texture1 = new THREE.TextureLoader().load("img/grid.png")
+// const texture2 = new THREE.TextureLoader().load("img/grid.png")
+
+const mipmap = (size: number, color: string) => {
+    const imageCanvas = document.createElement('canvas') as HTMLCanvasElement
+    const context = imageCanvas.getContext('2d') as CanvasRenderingContext2D
+    imageCanvas.width = size
+    imageCanvas.height = size
+    context.fillStyle = '#888888'
+    context.fillRect(0, 0, size, size)
+    context.fillStyle = color
+    context.fillRect(0, 0, size / 2, size / 2)
+    context.fillRect(size / 2, size / 2, size / 2, size / 2)
+    return imageCanvas
+}
+
+const blankCanvas = document.createElement('canvas') as HTMLCanvasElement
+blankCanvas.width = 128
+blankCanvas.height = 128
+
+const texture1 = new THREE.CanvasTexture(blankCanvas)
+texture1.mipmaps[0] = mipmap(128, '#ff0000')
+texture1.mipmaps[1] = mipmap(64, '#00ff00')
+texture1.mipmaps[2] = mipmap(32, '#0000ff')
+texture1.mipmaps[3] = mipmap(16, '#880000')
+texture1.mipmaps[4] = mipmap(8, '#008800')
+texture1.mipmaps[5] = mipmap(4, '#000088')
+texture1.mipmaps[6] = mipmap(2, '#008888')
+texture1.mipmaps[7] = mipmap(1, '#880088')
+texture1.repeat.set(5, 5)
+texture1.wrapS = THREE.RepeatWrapping
+texture1.wrapT = THREE.RepeatWrapping
+
 const texture2 = texture1.clone()
+texture2.minFilter = THREE.NearestFilter
+texture2.magFilter = THREE.NearestFilter
 
 const material1 = new THREE.MeshBasicMaterial({ map: texture1 })
 const material2 = new THREE.MeshBasicMaterial({ map: texture2 })
-
-texture2.minFilter = THREE.NearestFilter
-texture2.magFilter = THREE.NearestFilter
 
 const plane1 = new THREE.Mesh(planeGeometry1, material1)
 const plane2 = new THREE.Mesh(planeGeometry2, material2)
@@ -81,9 +112,7 @@ function updateMinFilter() {
     // texture2.needsUpdate = true
 
     // for Three r138 and later
-    material2.map = new THREE.TextureLoader().load('img/grid.png')
-    material2.map.minFilter = Number(texture2.minFilter)
-    material2.map.magFilter = Number(texture2.magFilter)
+    material2.map = texture2.clone()
 }
 function updateMagFilter() {
     // for Three r137 and earlier
@@ -91,9 +120,7 @@ function updateMagFilter() {
     // texture2.needsUpdate = true
 
     // for Three r138 and later
-    material2.map = new THREE.TextureLoader().load('img/grid.png')
-    material2.map.minFilter = Number(texture2.minFilter)
-    material2.map.magFilter = Number(texture2.magFilter)
+    material2.map = texture2.clone()
 }
 
 const stats = Stats()


### PR DESCRIPTION
Мы можем создавать свои собственные мип-карты, которые будут использоваться при отрисовке пикселей текстуры в зависимости от расстояния до камеры и необходимости уменьшения или увеличения текселя.