### PR TITLE
Spot Light Shadow

### DIFF
--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -87,11 +87,11 @@ torus[2].castShadow = true
 torus[3].castShadow = true
 torus[4].castShadow = true
 
-// torus[0].receiveShadow = true
-// torus[1].receiveShadow = true
-// torus[2].receiveShadow = true
-// torus[3].receiveShadow = true
-// torus[4].receiveShadow = true
+torus[0].receiveShadow = true
+torus[1].receiveShadow = true
+torus[2].receiveShadow = true
+torus[3].receiveShadow = true
+torus[4].receiveShadow = true
 
 scene.add(torus[0])
 scene.add(torus[1])

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -7,9 +7,15 @@ const scene = new THREE.Scene()
 scene.add(new THREE.AxesHelper(5))
 
 const light = new THREE.SpotLight()
+// light.castShadow = true;
+// light.shadow.mapSize.width = 512;
+// light.shadow.mapSize.height = 512;
+// light.shadow.camera.near = 0.5;
+// light.shadow.camera.far = 100
 scene.add(light)
 
 const helper = new THREE.SpotLightHelper(light)
+//const helper = new THREE.CameraHelper(light.shadow.camera);
 scene.add(helper)
 
 const camera = new THREE.PerspectiveCamera(
@@ -22,14 +28,20 @@ camera.position.z = 7
 
 const renderer = new THREE.WebGLRenderer()
 renderer.setSize(window.innerWidth, window.innerHeight)
+//renderer.shadowMap.enabled = true
+//renderer.shadowMap.type = THREE.PCFSoftShadowMap
+//renderer.shadowMap.type = THREE.BasicShadowMap
+//renderer.shadowMap.type = THREE.PCFShadowMap
+//renderer.shadowMap.type = THREE.VSMShadowMap
 document.body.appendChild(renderer.domElement)
 
 new OrbitControls(camera, renderer.domElement)
 
-const planeGeometry = new THREE.PlaneGeometry(100, 10)
+const planeGeometry = new THREE.PlaneGeometry(100, 20)
 const plane = new THREE.Mesh(planeGeometry, new THREE.MeshPhongMaterial())
 plane.rotateX(-Math.PI / 2)
 plane.position.y = -1.75
+//plane.receiveShadow = true;
 scene.add(plane)
 
 const torusGeometry = [
@@ -69,6 +81,18 @@ torus[2].position.x = 0
 torus[3].position.x = 4
 torus[4].position.x = 8
 
+// torus[0].castShadow = true
+// torus[1].castShadow = true
+// torus[2].castShadow = true
+// torus[3].castShadow = true
+// torus[4].castShadow = true
+
+// torus[0].receiveShadow = true
+// torus[1].receiveShadow = true
+// torus[2].receiveShadow = true
+// torus[3].receiveShadow = true
+// torus[4].receiveShadow = true
+
 scene.add(torus[0])
 scene.add(torus[1])
 scene.add(torus[2])
@@ -89,6 +113,8 @@ document.body.appendChild(stats.dom)
 const data = {
     color: light.color.getHex(),
     mapsEnabled: true,
+    //shadowMapSizeWidth: 512,
+    //shadowMapSizeHeight: 512,
 }
 
 const gui = new GUI()
@@ -97,16 +123,27 @@ lightFolder.addColor(data, 'color').onChange(() => {
     light.color.setHex(Number(data.color.toString().replace('#', '0x')))
 })
 lightFolder.add(light, 'intensity', 0, 1, 0.01)
-lightFolder.open()
+
 const spotLightFolder = gui.addFolder('THREE.SpotLight')
 spotLightFolder.add(light, 'distance', 0, 100, 0.01)
 spotLightFolder.add(light, 'decay', 0, 4, 0.1)
 spotLightFolder.add(light, 'angle', 0, 1, 0.1)
 spotLightFolder.add(light, 'penumbra', 0, 1, 0.1)
+//spotLightFolder.add(light.shadow.camera, "near", 0.1, 100).onChange(() => light.shadow.camera.updateProjectionMatrix())
+//spotLightFolder.add(light.shadow.camera, "far", 0.1, 100).onChange(() => light.shadow.camera.updateProjectionMatrix())
+//spotLightFolder.add(data, "shadowMapSizeWidth", [256, 512, 1024, 2048, 4096]).onChange(() => updateShadowMapSize())
+//spotLightFolder.add(data, "shadowMapSizeHeight", [256, 512, 1024, 2048, 4096]).onChange(() => updateShadowMapSize())
 spotLightFolder.add(light.position, 'x', -50, 50, 0.01)
 spotLightFolder.add(light.position, 'y', -50, 50, 0.01)
 spotLightFolder.add(light.position, 'z', -50, 50, 0.01)
 spotLightFolder.open()
+
+// function updateShadowMapSize() {
+//     light.shadow.mapSize.width = data.shadowMapSizeWidth
+//     light.shadow.mapSize.height = data.shadowMapSizeHeight
+//     ;(light.shadow.map as any) = null
+// }
+
 const meshesFolder = gui.addFolder('Meshes')
 meshesFolder.add(data, 'mapsEnabled').onChange(() => {
     material.forEach((m) => {

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -7,15 +7,15 @@ const scene = new THREE.Scene()
 scene.add(new THREE.AxesHelper(5))
 
 const light = new THREE.SpotLight()
-// light.castShadow = true;
-// light.shadow.mapSize.width = 512;
-// light.shadow.mapSize.height = 512;
-// light.shadow.camera.near = 0.5;
-// light.shadow.camera.far = 100
+light.castShadow = true;
+light.shadow.mapSize.width = 512;
+light.shadow.mapSize.height = 512;
+light.shadow.camera.near = 0.5;
+light.shadow.camera.far = 100
 scene.add(light)
 
-const helper = new THREE.SpotLightHelper(light)
-//const helper = new THREE.CameraHelper(light.shadow.camera);
+// const helper = new THREE.SpotLightHelper(light)
+const helper = new THREE.CameraHelper(light.shadow.camera);
 scene.add(helper)
 
 const camera = new THREE.PerspectiveCamera(
@@ -28,8 +28,8 @@ camera.position.z = 7
 
 const renderer = new THREE.WebGLRenderer()
 renderer.setSize(window.innerWidth, window.innerHeight)
-//renderer.shadowMap.enabled = true
-//renderer.shadowMap.type = THREE.PCFSoftShadowMap
+renderer.shadowMap.enabled = true
+renderer.shadowMap.type = THREE.PCFSoftShadowMap
 //renderer.shadowMap.type = THREE.BasicShadowMap
 //renderer.shadowMap.type = THREE.PCFShadowMap
 //renderer.shadowMap.type = THREE.VSMShadowMap
@@ -41,7 +41,7 @@ const planeGeometry = new THREE.PlaneGeometry(100, 20)
 const plane = new THREE.Mesh(planeGeometry, new THREE.MeshPhongMaterial())
 plane.rotateX(-Math.PI / 2)
 plane.position.y = -1.75
-//plane.receiveShadow = true;
+plane.receiveShadow = true;
 scene.add(plane)
 
 const torusGeometry = [
@@ -81,11 +81,11 @@ torus[2].position.x = 0
 torus[3].position.x = 4
 torus[4].position.x = 8
 
-// torus[0].castShadow = true
-// torus[1].castShadow = true
-// torus[2].castShadow = true
-// torus[3].castShadow = true
-// torus[4].castShadow = true
+torus[0].castShadow = true
+torus[1].castShadow = true
+torus[2].castShadow = true
+torus[3].castShadow = true
+torus[4].castShadow = true
 
 // torus[0].receiveShadow = true
 // torus[1].receiveShadow = true

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -30,9 +30,9 @@ const renderer = new THREE.WebGLRenderer()
 renderer.setSize(window.innerWidth, window.innerHeight)
 renderer.shadowMap.enabled = true
 renderer.shadowMap.type = THREE.PCFSoftShadowMap
-//renderer.shadowMap.type = THREE.BasicShadowMap
-//renderer.shadowMap.type = THREE.PCFShadowMap
-//renderer.shadowMap.type = THREE.VSMShadowMap
+// renderer.shadowMap.type = THREE.BasicShadowMap
+// renderer.shadowMap.type = THREE.PCFShadowMap
+// renderer.shadowMap.type = THREE.VSMShadowMap
 document.body.appendChild(renderer.domElement)
 
 new OrbitControls(camera, renderer.domElement)
@@ -113,8 +113,8 @@ document.body.appendChild(stats.dom)
 const data = {
     color: light.color.getHex(),
     mapsEnabled: true,
-    //shadowMapSizeWidth: 512,
-    //shadowMapSizeHeight: 512,
+    shadowMapSizeWidth: 512,
+    shadowMapSizeHeight: 512,
 }
 
 const gui = new GUI()
@@ -131,18 +131,18 @@ spotLightFolder.add(light, 'angle', 0, 1, 0.1)
 spotLightFolder.add(light, 'penumbra', 0, 1, 0.1)
 //spotLightFolder.add(light.shadow.camera, "near", 0.1, 100).onChange(() => light.shadow.camera.updateProjectionMatrix())
 //spotLightFolder.add(light.shadow.camera, "far", 0.1, 100).onChange(() => light.shadow.camera.updateProjectionMatrix())
-//spotLightFolder.add(data, "shadowMapSizeWidth", [256, 512, 1024, 2048, 4096]).onChange(() => updateShadowMapSize())
-//spotLightFolder.add(data, "shadowMapSizeHeight", [256, 512, 1024, 2048, 4096]).onChange(() => updateShadowMapSize())
+spotLightFolder.add(data, "shadowMapSizeWidth", [256, 512, 1024, 2048, 4096]).onChange(() => updateShadowMapSize())
+spotLightFolder.add(data, "shadowMapSizeHeight", [256, 512, 1024, 2048, 4096]).onChange(() => updateShadowMapSize())
 spotLightFolder.add(light.position, 'x', -50, 50, 0.01)
 spotLightFolder.add(light.position, 'y', -50, 50, 0.01)
 spotLightFolder.add(light.position, 'z', -50, 50, 0.01)
 spotLightFolder.open()
 
-// function updateShadowMapSize() {
-//     light.shadow.mapSize.width = data.shadowMapSizeWidth
-//     light.shadow.mapSize.height = data.shadowMapSizeHeight
-//     ;(light.shadow.map as any) = null
-// }
+function updateShadowMapSize() {
+    light.shadow.mapSize.width = data.shadowMapSizeWidth
+    light.shadow.mapSize.height = data.shadowMapSizeHeight
+    ;(light.shadow.map as any) = null
+}
 
 const meshesFolder = gui.addFolder('Meshes')
 meshesFolder.add(data, 'mapsEnabled').onChange(() => {


### PR DESCRIPTION
Spot Light Shadow использует усеченную камеру PerspectiveCamera для расчета теней.

Значения PerspectiveCamera по умолчанию:

| Направление | Значение |
|--------------------|----------|
| near                |  0.5     |
| far                   | Если для собственного прожектора установлено значения выше 0, оно будет использоваться, в противном случае используется значение по умолчанию 500 |
| fov                  | Свойство угла прожектора-владельца |
| aspect            | mapSize, по умолчанию 512/512 = 1  |

