### PR TITLE
Textured GLTF

### DIFF
--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -21,6 +21,7 @@ camera.position.z = 3;
 const renderer = new THREE.WebGLRenderer();
 renderer.physicallyCorrectLights = true;
 renderer.shadowMap.enabled = true;
+renderer.outputEncoding = THREE.sRGBEncoding;
 renderer.setSize(window.innerWidth, window.innerHeight);
 document.body.appendChild(renderer.domElement);
 


### PR DESCRIPTION
Демонстрация добавления в модель glTF текстуры и изменение ее UV-координат. По умолчанию текстура встраивается в модель, когда мы экспортируем ее из блендера. Это упрощает создание и использование текстурированных моделей по сравнению с использованием OBJ и MTL.